### PR TITLE
Fix direction bug in PhysicsUpdateSystem

### DIFF
--- a/src/glaze/physics/systems/PhysicsUpdateSystem.ts
+++ b/src/glaze/physics/systems/PhysicsUpdateSystem.ts
@@ -21,6 +21,14 @@ export class PhysicsUpdateSystem extends System {
 
     updateEntity(entity: Entity, position: Position, physicsBody: PhysicsBody, active: Active) {
         physicsBody.body.update(this.dt / 1000, this.globalForce, this.globalDamping);
-        position.direction.x = physicsBody.body.velocity.x > 0 ? 1 : -1;
+
+        // If the body is moving in the X direction, update the direction vector
+        // to match the direction of the velocity.
+        // Note that if the X velocity is zero, the direction will remain unchanged.
+        if (physicsBody.body.velocity.x > 0) {
+            position.direction.x = 1
+        } else if (physicsBody.body.velocity.x < 0) {
+            position.direction.x = -1
+        }
     }
 }


### PR DESCRIPTION
In the prior version of `PhysicsUpdateSystem` logic, if the `PhysicsBody.body.velocity.x`
velocity is zero, the `Position.direction.x` will always be updated to point to the negative direction.

This was causing the following problematic behavior:
- an entity that "walks" rightward and is stopped by a "wall"
  will switch to facing left when it comes to a stop
- an entity that "walks" leftward and is stopped by a "wall"
  will continue facing left when it comes to a stop

After this commit, the behavior is fixed and made consistent by ensuring that
when the X velocity is zero we do not update the X direction.